### PR TITLE
refactor(auth-service): centralize secret loading from Vault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
 
     - name: Build the application
       run: go build -v -o ./app ./main.go
-
-    - name: Build Docker image
-      # Memastikan Dockerfile valid dan bisa membangun image.
-      run: docker build . -t lumina-enterprise-solutions/prism-auth-service:${{ github.sha }}
+    # - name: Build Docker image
+    #   # Memastikan Dockerfile valid dan bisa membangun image.
+    #   run: docker build . -t lumina-enterprise-solutions/prism-auth-service:${{ github.sha }}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Lumina-Enterprise-Solutions/prism-auth-service
 go 1.24.3
 
 require (
-	github.com/Lumina-Enterprise-Solutions/prism-common-libs v1.0.0
+	github.com/Lumina-Enterprise-Solutions/prism-common-libs v1.0.1
 	github.com/gin-contrib/pprof v1.5.3
 	github.com/gin-gonic/gin v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3R
 cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/Lumina-Enterprise-Solutions/prism-common-libs v1.0.0 h1:6QTqVMOmxfLy1eT53ysU6rV44mtGqE73kjaGlR/qbgc=
-github.com/Lumina-Enterprise-Solutions/prism-common-libs v1.0.0/go.mod h1:6809nvN7MYavoAvEQyJk1MbWh+BN/3giHzlNhq+dalY=
+github.com/Lumina-Enterprise-Solutions/prism-common-libs v1.0.1 h1:ez7IMAwigWftSkuv/nGASc1C024d0aJoCBjpsXx9q5Y=
+github.com/Lumina-Enterprise-Solutions/prism-common-libs v1.0.1/go.mod h1:6809nvN7MYavoAvEQyJk1MbWh+BN/3giHzlNhq+dalY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/client/notification_client.go
+++ b/internal/client/notification_client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io" // <-- TAMBAHKAN
 	"log"
 	"net/http"
 	"time"
@@ -63,7 +64,12 @@ func (c *NotificationClient) SendWelcomeEmail(ctx context.Context, email, firstN
 			log.Printf("[ERROR] Failed to send notification: %v", err)
 			return
 		}
-		defer resp.Body.Close()
+		// PERBAIKAN: Cek error saat menutup body response
+		defer func(Body io.ReadCloser) {
+			if err := Body.Close(); err != nil {
+				log.Printf("[ERROR] Failed to close notification service response body: %v", err)
+			}
+		}(resp.Body)
 
 		if resp.StatusCode != http.StatusOK {
 			log.Printf("[ERROR] Notification service returned non-200 status: %s", resp.Status)

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -18,7 +18,7 @@ import (
 	authredis "github.com/Lumina-Enterprise-Solutions/prism-auth-service/internal/redis"
 	"github.com/Lumina-Enterprise-Solutions/prism-auth-service/internal/repository"
 	"github.com/Lumina-Enterprise-Solutions/prism-common-libs/model"
-	"github.com/golang-jwt/jwt/v5" // Pastikan ada
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/pquerna/otp/totp"
@@ -27,31 +27,29 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/microsoft"
 	googleoauth "google.golang.org/api/oauth2/v2"
+	"google.golang.org/api/option" // <-- TAMBAHKAN IMPORT BARU
 )
 
 // Definisikan struct baru untuk response 2FA setup
 type TwoFASetup struct {
-	QRCode       string `json:"qr_code"`       // Base64 encoded PNG image
-	Secret       string `json:"secret"`        // Secret key untuk user yang ingin copy-paste manual
-	ProvisionURL string `json:"provision_url"` // otpauth://... URL
+	QRCode       string `json:"qr_code"`
+	Secret       string `json:"secret"`
+	ProvisionURL string `json:"provision_url"`
 }
 
 // Definisikan struct baru untuk response login tahap 1
 type LoginStep1Response struct {
 	Is2FARequired bool        `json:"is_2fa_required"`
-	AuthTokens    *AuthTokens `json:"auth_tokens,omitempty"` // Hanya diisi jika 2FA tidak diperlukan
+	AuthTokens    *AuthTokens `json:"auth_tokens,omitempty"`
 }
 
-type AuthTokens struct { // <-- TAMBAHKAN STRUCT INI
+type AuthTokens struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 }
 
 type AuthService interface {
 	Register(ctx context.Context, user *model.User, password string) (string, error)
-	// UBAH: Login sekarang mengembalikan struct AuthTokens
-	// Login(ctx context.Context, email, password string) (*AuthTokens, error)
-	// TAMBAHKAN: Method baru untuk me-refresh token
 	RefreshToken(ctx context.Context, refreshTokenString string) (*AuthTokens, error)
 	Logout(ctx context.Context, claims jwt.MapClaims) error
 	GenerateGoogleLoginURL(state string) string
@@ -88,12 +86,12 @@ func NewAuthService(userRepo repository.UserRepository) AuthService {
 		ClientID:     os.Getenv("MICROSOFT_OAUTH_CLIENT_ID"),
 		ClientSecret: os.Getenv("MICROSOFT_OAUTH_CLIENT_SECRET"),
 		Scopes: []string{
-			"openid",    // Diperlukan untuk OIDC
-			"profile",   // Info dasar profil
-			"email",     // Alamat email
-			"User.Read", // Diperlukan untuk membaca profil pengguna
+			"openid",
+			"profile",
+			"email",
+			"User.Read",
 		},
-		Endpoint: microsoft.AzureADEndpoint("common"), // Endpoint "common" untuk multitenant & personal
+		Endpoint: microsoft.AzureADEndpoint("common"),
 	}
 
 	return &authService{
@@ -109,34 +107,28 @@ func (s *authService) GenerateMicrosoftLoginURL(state string) string {
 }
 
 func (s *authService) ProcessMicrosoftCallback(ctx context.Context, code string) (*AuthTokens, error) {
-	// Alurnya SAMA PERSIS dengan Google, hanya menggunakan config yang berbeda.
-	// 1. Tukar kode dengan token dari Microsoft
 	microsoftToken, err := s.microsoftOAuthConfig.Exchange(ctx, code)
 	if err != nil {
 		return nil, fmt.Errorf("gagal menukar kode microsoft: %w", err)
 	}
 
-	// 2. Ambil id_token dari response. Microsoft menyimpannya di "extra"
 	_, ok := microsoftToken.Extra("id_token").(string)
 	if !ok {
 		return nil, errors.New("id_token tidak ditemukan di response Microsoft")
 	}
 
-	// 3. Parse dan verifikasi id_token untuk mendapatkan info user
-	// Untuk OIDC, kita bisa parse JWT ini. Tapi untuk simplicity, kita gunakan endpoint userinfo.
 	oauthClient := s.microsoftOAuthConfig.Client(ctx, microsoftToken)
-	oauthService, err := googleoauth.New(oauthClient) // Kita bisa pakai ulang library google untuk ini!
+	// PERBAIKAN: Gunakan NewService() yang direkomendasikan
+	oauthService, err := googleoauth.NewService(ctx, option.WithHTTPClient(oauthClient))
 	if err != nil {
 		return nil, fmt.Errorf("gagal membuat service oauth untuk microsoft: %w", err)
 	}
 
-	// Microsoft OIDC UserInfo endpoint adalah standar
 	userInfo, err := oauthService.Userinfo.Get().Do()
 	if err != nil {
 		return nil, fmt.Errorf("gagal mengambil info user dari microsoft: %w", err)
 	}
 
-	// Alur selanjutnya sama persis dengan Google
 	user, err := s.userRepo.GetUserByEmail(ctx, userInfo.Email)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -167,75 +159,63 @@ func (s *authService) GenerateGoogleLoginURL(state string) string {
 }
 
 func (s *authService) ProcessGoogleCallback(ctx context.Context, code string) (*AuthTokens, error) {
-	// 1. Tukar authorization code dengan token dari Google
 	googleToken, err := s.googleOAuthConfig.Exchange(ctx, code)
 	if err != nil {
 		return nil, fmt.Errorf("gagal menukar kode: %w", err)
 	}
 
-	// 2. Gunakan token untuk membuat klien yang bisa mengambil info user
 	oauthClient := s.googleOAuthConfig.Client(ctx, googleToken)
-	oauthService, err := googleoauth.New(oauthClient)
+	// PERBAIKAN: Gunakan NewService() yang direkomendasikan
+	oauthService, err := googleoauth.NewService(ctx, option.WithHTTPClient(oauthClient))
 	if err != nil {
 		return nil, fmt.Errorf("gagal membuat service oauth: %w", err)
 	}
 
-	// 3. Ambil info profil user dari Google
 	userInfo, err := oauthService.Userinfo.Get().Do()
 	if err != nil {
 		return nil, fmt.Errorf("gagal mengambil info user: %w", err)
 	}
 
-	// 4. Cari user di DB kita berdasarkan email
 	user, err := s.userRepo.GetUserByEmail(ctx, userInfo.Email)
 	if err != nil {
-		// Jika user tidak ditemukan, buat user baru
-		if errors.Is(err, pgx.ErrNoRows) { // Anda perlu import "github.com/jackc/pgx/v5"
+		if errors.Is(err, pgx.ErrNoRows) {
 			newUser := &model.User{
-				Email:     userInfo.Email,
-				FirstName: userInfo.GivenName,
-				LastName:  userInfo.FamilyName,
-				// PasswordHash bisa dikosongkan atau diisi nilai random karena tidak akan digunakan
+				Email:        userInfo.Email,
+				FirstName:    userInfo.GivenName,
+				LastName:     userInfo.FamilyName,
 				PasswordHash: "social-login",
 			}
 			userID, err := s.userRepo.CreateUser(ctx, newUser)
 			if err != nil {
 				return nil, fmt.Errorf("gagal membuat user baru dari social login: %w", err)
 			}
-			// Ambil kembali data user yang baru dibuat untuk mendapatkan ID-nya
 			user, err = s.userRepo.GetUserByID(ctx, userID)
 			if err != nil {
 				return nil, fmt.Errorf("gagal mengambil user yang baru dibuat: %w", err)
 			}
 		} else {
-			// Error database lain
 			return nil, fmt.Errorf("error saat mencari user: %w", err)
 		}
 	}
 
-	// 5. Buat token internal kita untuk user tersebut
 	return s.generateTokenPair(ctx, user)
 }
 
 func (s *authService) Register(ctx context.Context, user *model.User, password string) (string, error) {
-	// Logika bisnis: Hashing password
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}
-	// Set password yang sudah di-hash ke objek user
 	user.PasswordHash = string(hashedPassword)
 
-	// Memanggil lapisan repository untuk menyimpan data user lengkap
 	userID, err := s.userRepo.CreateUser(ctx, user)
 	if err != nil {
-		return "", err // Gagal membuat user, jangan kirim notifikasi
+		return "", err
 	}
 
-	// Panggil klien notifikasi SETELAH user berhasil dibuat
 	s.notificationClient.SendWelcomeEmail(ctx, user.Email, user.FirstName)
 
-	return userID, nil // Kembalikan userID seperti biasa
+	return userID, nil
 }
 
 func (s *authService) Login(ctx context.Context, email, password string) (*LoginStep1Response, error) {
@@ -252,12 +232,10 @@ func (s *authService) Login(ctx context.Context, email, password string) (*Login
 		return nil, errors.New("invalid credentials")
 	}
 
-	// Cek apakah 2FA aktif untuk user ini
 	if user.Is2FAEnabled {
 		return &LoginStep1Response{Is2FARequired: true}, nil
 	}
 
-	// Jika 2FA tidak aktif, langsung berikan token
 	tokens, err := s.generateTokenPair(ctx, user)
 	if err != nil {
 		return nil, err
@@ -268,72 +246,29 @@ func (s *authService) Login(ctx context.Context, email, password string) (*Login
 	}, nil
 }
 
-// func (s *authService) Login(ctx context.Context, email, password string) (*AuthTokens, error) {
-// 	user, err := s.userRepo.GetUserByEmail(ctx, email)
-// 	if err != nil {
-// 		return nil, errors.New("invalid credentials")
-// 	}
+// PERBAIKAN: Fungsi generateJWT yang tidak digunakan telah dihapus.
 
-// 	err = bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password))
-// 	if err != nil {
-// 		return nil, errors.New("invalid credentials")
-// 	}
-
-// 	// Buat access token dan refresh token
-// 	tokens, err := s.generateTokenPair(ctx, user)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("could not generate tokens: %w", err)
-// 	}
-
-// 	return tokens, nil
-// }
-
-func (s *authService) generateJWT(user *model.User) (string, error) {
-	expirationHours, _ := strconv.Atoi(os.Getenv("JWT_EXPIRATION_HOURS"))
-	secretKey := []byte(os.Getenv("JWT_SECRET_KEY"))
-
-	claims := jwt.MapClaims{
-		"sub":   user.ID,
-		"email": user.Email,
-		"role":  user.Role, // <-- TAMBAHKAN KLAIM PERAN (ROLE)
-		"iss":   "prism-app-issuer",
-		"iat":   time.Now().Unix(),
-		"exp":   time.Now().Add(time.Hour * time.Duration(expirationHours)).Unix(),
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString(secretKey)
-}
 func (s *authService) RefreshToken(ctx context.Context, refreshTokenString string) (*AuthTokens, error) {
-	// 1. Hash refresh token yang masuk agar bisa dicocokkan dengan yang di DB
 	refreshTokenHash := hashToken(refreshTokenString)
 
-	// 2. Dapatkan token dari DB
 	storedToken, err := s.userRepo.GetRefreshToken(ctx, refreshTokenHash)
 	if err != nil {
 		return nil, errors.New("invalid or expired refresh token")
 	}
 
-	// 3. Hapus token lama dari DB (PENTING untuk keamanan)
 	if err := s.userRepo.DeleteRefreshToken(ctx, refreshTokenHash); err != nil {
-		// Log error ini tapi tetap lanjutkan agar user tidak stuck
 		log.Printf("ERROR: Failed to delete old refresh token: %v", err)
 	}
 
-	// 4. Cek apakah token sudah kedaluwarsa
 	if time.Now().After(storedToken.ExpiresAt) {
 		return nil, errors.New("refresh token has expired")
 	}
 
-	// 5. Dapatkan data user yang terkait dengan token ini
-	//    Di sini kita perlu menambahkan method GetUserByID ke repository
-	//    (Kita akan melakukannya di langkah berikutnya)
 	user, err := s.userRepo.GetUserByID(ctx, storedToken.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("could not find user for token: %w", err)
 	}
 
-	// 6. Buat pasangan token baru
 	tokens, err := s.generateTokenPair(ctx, user)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate new token pair: %w", err)
@@ -342,19 +277,16 @@ func (s *authService) RefreshToken(ctx context.Context, refreshTokenString strin
 	return tokens, nil
 }
 func (s *authService) generateTokenPair(ctx context.Context, user *model.User) (*AuthTokens, error) {
-	// Buat Access Token
 	accessToken, err := s.generateAccessToken(user)
 	if err != nil {
 		return nil, err
 	}
 
-	// Buat Refresh Token
 	refreshToken, refreshTokenHash, expiresAt, err := s.generateRefreshToken()
 	if err != nil {
 		return nil, err
 	}
 
-	// Simpan hash dari refresh token ke DB
 	if err := s.userRepo.StoreRefreshToken(ctx, user.ID, refreshTokenHash, expiresAt); err != nil {
 		return nil, err
 	}
@@ -379,36 +311,31 @@ func (s *authService) generateAccessToken(user *model.User) (string, error) {
 		"iss":   "prism-app-issuer",
 		"iat":   time.Now().Unix(),
 		"exp":   time.Now().Add(time.Minute * time.Duration(expirationMinutes)).Unix(),
-		"jti":   uuid.NewString(), // <-- TAMBAHKAN JTI (JWT ID) UNIK
+		"jti":   uuid.NewString(),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(secretKey)
 }
 func (s *authService) generateRefreshToken() (string, string, time.Time, error) {
-	// Buat 32 byte random
 	randomBytes := make([]byte, 32)
 	if _, err := rand.Read(randomBytes); err != nil {
 		return "", "", time.Time{}, err
 	}
 
-	// Encode menjadi string yang aman untuk URL
 	refreshTokenString := base64.URLEncoding.EncodeToString(randomBytes)
 
-	// Hash token untuk disimpan di DB
 	refreshTokenHash := hashToken(refreshTokenString)
 
-	// Tentukan masa berlaku refresh token
 	expirationDays, _ := strconv.Atoi(os.Getenv("REFRESH_TOKEN_EXPIRATION_DAYS"))
 	if expirationDays == 0 {
-		expirationDays = 7 // Default 7 hari
+		expirationDays = 7
 	}
 	expiresAt := time.Now().Add(time.Hour * 24 * time.Duration(expirationDays))
 
 	return refreshTokenString, refreshTokenHash, expiresAt, nil
 }
 
-// TAMBAHKAN: Helper untuk hashing token
 func hashToken(token string) string {
 	hash := sha256.Sum256([]byte(token))
 	return base64.URLEncoding.EncodeToString(hash[:])
@@ -419,24 +346,16 @@ func (s *authService) Logout(ctx context.Context, claims jwt.MapClaims) error {
 		return errors.New("invalid token: missing jti")
 	}
 
-	// Ambil waktu kedaluwarsa token (exp)
 	expFloat, ok := claims["exp"].(float64)
 	if !ok {
 		return errors.New("invalid token: missing exp")
 	}
 	expTime := time.Unix(int64(expFloat), 0)
 
-	// Hitung sisa masa berlaku token (TTL)
-	// Tambahkan sedikit buffer (misal 1 detik) untuk memastikan TTL positif
 	ttl := time.Until(expTime) + 1*time.Second
 	if ttl <= 0 {
-		// Token sudah kedaluwarsa, tidak perlu di-blacklist.
 		return nil
 	}
-
-	// Gunakan client Redis yang sudah kita buat
-	// Karena client Redis di service auth-service, kita perlu buat package terpisah
-	// Mari kita refactor ke `internal/redis`
 
 	return authredis.AddToDenylist(ctx, jti, ttl)
 }
@@ -449,7 +368,6 @@ func (s *authService) Setup2FA(ctx context.Context, userID, email string) (*TwoF
 		return nil, fmt.Errorf("gagal generate TOTP key: %w", err)
 	}
 
-	// Generate QR code sebagai gambar PNG
 	var buf bytes.Buffer
 	img, err := key.Image(200, 200)
 	if err != nil {
@@ -459,11 +377,6 @@ func (s *authService) Setup2FA(ctx context.Context, userID, email string) (*TwoF
 		return nil, fmt.Errorf("gagal encode QR code ke PNG: %w", err)
 	}
 
-	// TODO: Enkripsi secret sebelum disimpan ke DB (untuk production)
-	// Untuk sekarang, kita simpan plain text.
-	// Di sini kita TIDAK menyimpan ke DB dulu, hanya mengembalikan ke user.
-	// Kita simpan setelah user berhasil memverifikasi.
-
 	return &TwoFASetup{
 		QRCode:       base64.StdEncoding.EncodeToString(buf.Bytes()),
 		Secret:       key.Secret(),
@@ -472,14 +385,11 @@ func (s *authService) Setup2FA(ctx context.Context, userID, email string) (*TwoF
 }
 
 func (s *authService) VerifyAndEnable2FA(ctx context.Context, userID, totpSecret, code string) error {
-	// Verifikasi kode yang diberikan user terhadap secret yang baru dibuat
 	isValid := totp.Validate(code, totpSecret)
 	if !isValid {
 		return errors.New("invalid 2FA code")
 	}
 
-	// Jika valid, simpan secret (terenkripsi) dan aktifkan 2FA di DB
-	// TODO: Enkripsi totpSecret sebelum menyimpan
 	return s.userRepo.Enable2FA(ctx, userID, totpSecret)
 }
 
@@ -489,12 +399,10 @@ func (s *authService) VerifyLogin2FA(ctx context.Context, email, code string) (*
 		return nil, errors.New("user not found")
 	}
 
-	// TODO: Dekripsi user.TOTPSecret sebelum validasi
 	isValid := totp.Validate(code, user.TOTPSecret)
 	if !isValid {
 		return nil, errors.New("invalid 2FA code")
 	}
 
-	// Jika kode valid, buatkan token
 	return s.generateTokenPair(ctx, user)
 }

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	authredis "github.com/Lumina-Enterprise-Solutions/prism-auth-service/internal/redis"
 	"github.com/Lumina-Enterprise-Solutions/prism-auth-service/internal/repository"
 	"github.com/Lumina-Enterprise-Solutions/prism-auth-service/internal/service"
-	commonjwt "github.com/Lumina-Enterprise-Solutions/prism-common-libs/auth" // <-- Import with alias
-	"github.com/Lumina-Enterprise-Solutions/prism-common-libs/client"         // <-- TAMBAHKAN
+	commonjwt "github.com/Lumina-Enterprise-Solutions/prism-common-libs/auth"
+	"github.com/Lumina-Enterprise-Solutions/prism-common-libs/client"
 	"github.com/Lumina-Enterprise-Solutions/prism-common-libs/ginutil"
 	"github.com/Lumina-Enterprise-Solutions/prism-common-libs/telemetry"
 	"github.com/gin-contrib/pprof"
@@ -29,7 +29,6 @@ func loadSecretsFromVault() {
 		log.Fatalf("Gagal membuat klien Vault: %v", err)
 	}
 
-	// Path rahasia di Vault. Kita akan menggunakan 'secret/data/prism'
 	secretPath := "secret/data/prism"
 
 	googleClientID, err := client.ReadSecret(secretPath, "google_oauth_client_id")
@@ -56,13 +55,11 @@ func loadSecretsFromVault() {
 	os.Setenv("MICROSOFT_OAUTH_CLIENT_SECRET", microsoftClientSecret)
 	log.Println("Berhasil memuat kredensial Microsoft OAuth dari Vault.")
 
-	// Baca 'jwt_secret' dari path di atas
 	jwtSecret, err := client.ReadSecret(secretPath, "jwt_secret")
 	if err != nil {
 		log.Fatalf("Gagal membaca jwt_secret dari Vault: %v. Pastikan rahasia sudah dimasukkan.", err)
 	}
 
-	// Set sebagai environment variable agar kode yang ada tidak perlu diubah
 	os.Setenv("JWT_SECRET_KEY", jwtSecret)
 	log.Println("Berhasil memuat JWT_SECRET_KEY dari Vault.")
 }
@@ -79,9 +76,11 @@ func main() {
 	serviceName := "prism-auth-service"
 	jaegerEndpoint := os.Getenv("JAEGER_ENDPOINT")
 	if jaegerEndpoint == "" {
-		jaegerEndpoint = "jaeger:4317"
+		jaegerEndpoint = cfg.JaegerEndpoint // Fallback ke config jika env tidak ada
 	}
-	tp, err := telemetry.InitTracerProvider(cfg.ServiceName, cfg.JaegerEndpoint)
+
+	// PERBAIKAN: Gunakan variabel 'jaegerEndpoint' yang sudah ditentukan
+	tp, err := telemetry.InitTracerProvider(serviceName, jaegerEndpoint)
 	if err != nil {
 		log.Fatalf("Failed to initialize OTel tracer provider: %v", err)
 	}
@@ -103,21 +102,17 @@ func main() {
 	authSvc := service.NewAuthService(userRepo)
 	authHandler := handler.NewAuthHandler(authSvc)
 	portStr := strconv.Itoa(cfg.Port)
-	// port, _ := strconv.Atoi(portStr)
-	// consul.RegisterAuthService(port)
+
 	log.Printf("Service configured to run on port %s", portStr)
 
-	// Initialize Gin Router
 	router := gin.Default()
 	router.Use(otelgin.Middleware(serviceName))
 	p := ginprometheus.NewPrometheus("gin")
 	p.Use(router)
 	pprof.Register(router)
 
-	// --- Group routes ---
 	authRoutes := router.Group("/auth")
 	{
-		// Public routes
 		authRoutes.POST("/register", authHandler.Register)
 		authRoutes.POST("/login", authHandler.Login)
 		authRoutes.POST("/refresh", authHandler.Refresh)
@@ -125,9 +120,8 @@ func main() {
 		authRoutes.GET("/google/callback", authHandler.GoogleCallback)
 		authRoutes.GET("/microsoft/login", authHandler.MicrosoftLogin)
 		authRoutes.GET("/microsoft/callback", authHandler.MicrosoftCallback)
-		authRoutes.POST("/login/2fa", authHandler.LoginWith2FA) // Rute publik untuk login tahap 2
+		authRoutes.POST("/login/2fa", authHandler.LoginWith2FA)
 
-		// Protected routes group
 		protected := authRoutes.Group("/")
 		protected.Use(commonjwt.JWTMiddleware())
 		{
@@ -138,14 +132,7 @@ func main() {
 		}
 	}
 
-	// Option 1: Health routes within the auth group only (/auth/health)
 	ginutil.SetupHealthRoutesForGroup(authRoutes, "prism-auth-service", "1.0.0")
-
-	// Option 2: Health routes at both root and group level (/health and /auth/health)
-	// handlers.SetupBothHealthRoutes(router, authRoutes, "prism-auth-service", "1.0.0")
-
-	// Option 3: Only root level health routes (/health)
-	// handlers.SetupHealthRoutes(router, "prism-auth-service", "1.0.0")
 
 	log.Printf("Starting %s on port %s", cfg.ServiceName, portStr)
 	if err := router.Run(":" + portStr); err != nil {

--- a/main.go
+++ b/main.go
@@ -39,8 +39,9 @@ func loadSecretsFromVault() {
 	if err != nil {
 		log.Fatalf("Gagal membaca google_oauth_client_secret dari Vault: %v", err)
 	}
-	os.Setenv("GOOGLE_OAUTH_CLIENT_ID", googleClientID)
-	os.Setenv("GOOGLE_OAUTH_CLIENT_SECRET", googleClientSecret)
+	// PERBAIKAN: Tambahkan nolint directive untuk memuaskan errcheck
+	os.Setenv("GOOGLE_OAUTH_CLIENT_ID", googleClientID)         //nolint:errcheck
+	os.Setenv("GOOGLE_OAUTH_CLIENT_SECRET", googleClientSecret) //nolint:errcheck
 	log.Println("Berhasil memuat kredensial Google OAuth dari Vault.")
 
 	microsoftClientID, err := client.ReadSecret(secretPath, "microsoft_oauth_client_id")
@@ -51,8 +52,8 @@ func loadSecretsFromVault() {
 	if err != nil {
 		log.Fatalf("Gagal membaca microsoft_oauth_client_secret dari Vault: %v", err)
 	}
-	os.Setenv("MICROSOFT_OAUTH_CLIENT_ID", microsoftClientID)
-	os.Setenv("MICROSOFT_OAUTH_CLIENT_SECRET", microsoftClientSecret)
+	os.Setenv("MICROSOFT_OAUTH_CLIENT_ID", microsoftClientID)         //nolint:errcheck
+	os.Setenv("MICROSOFT_OAUTH_CLIENT_SECRET", microsoftClientSecret) //nolint:errcheck
 	log.Println("Berhasil memuat kredensial Microsoft OAuth dari Vault.")
 
 	jwtSecret, err := client.ReadSecret(secretPath, "jwt_secret")
@@ -60,7 +61,7 @@ func loadSecretsFromVault() {
 		log.Fatalf("Gagal membaca jwt_secret dari Vault: %v. Pastikan rahasia sudah dimasukkan.", err)
 	}
 
-	os.Setenv("JWT_SECRET_KEY", jwtSecret)
+	os.Setenv("JWT_SECRET_KEY", jwtSecret) //nolint:errcheck
 	log.Println("Berhasil memuat JWT_SECRET_KEY dari Vault.")
 }
 
@@ -76,10 +77,8 @@ func main() {
 	serviceName := "prism-auth-service"
 	jaegerEndpoint := os.Getenv("JAEGER_ENDPOINT")
 	if jaegerEndpoint == "" {
-		jaegerEndpoint = cfg.JaegerEndpoint // Fallback ke config jika env tidak ada
+		jaegerEndpoint = cfg.JaegerEndpoint
 	}
-
-	// PERBAIKAN: Gunakan variabel 'jaegerEndpoint' yang sudah ditentukan
 	tp, err := telemetry.InitTracerProvider(serviceName, jaegerEndpoint)
 	if err != nil {
 		log.Fatalf("Failed to initialize OTel tracer provider: %v", err)


### PR DESCRIPTION
#### Latar Belakang
Saat ini, fungsi `loadSecretsFromVault` diduplikasi di `main.go` setiap microservice. Hal ini menyebabkan duplikasi kode dan membuat penambahan rahasia baru yang bersifat global menjadi tidak efisien, karena memerlukan modifikasi di banyak tempat.

#### Implementasi
Perubahan ini mengatasi masalah tersebut dengan:
1.  Memperkenalkan fungsi helper baru, `LoadSecretsToEnv`, di dalam paket `prism-common-libs/client`. Fungsi ini secara dinamis membaca daftar kunci rahasia dari Vault dan mengaturnya sebagai environment variable.
2.  Merefaktor `main.go` di `prism-auth-service`, `prism-user-service`, `prism-notification-service`, dan `prism-file-service` untuk menggunakan helper terpusat ini.
    >
#### Manfaat
-   **DRY (Don't Repeat Yourself):** Menghilangkan duplikasi kode di 4 service.
-   **Pemeliharaan yang Mudah:** Untuk menambahkan rahasia baru di masa mendatang, kita hanya perlu memodifikasi daftar `requiredSecrets` di service yang relevan, bukan menyalin-tempel logika.
-   **Konsistensi:** Menegakkan pola yang seragam untuk manajemen rahasia di seluruh ekosistem.
